### PR TITLE
Uppercaseの削除

### DIFF
--- a/themes/docdock/static/theme-flex/style.css
+++ b/themes/docdock/static/theme-flex/style.css
@@ -309,7 +309,6 @@ article section.page {
     margin: 3rem 0rem;
     font-family: 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', '游ゴシック', 'YuGothic', Meiryo, sans-serif;
     text-align: center;
-    text-transform: uppercase;
     color: #060606;
     font-weight: 200;
     font-size: 3.25rem;


### PR DESCRIPTION
### Checklist
- [ ] `hugo server` command works fine locally.
- [ ] Table layout looks as it should be.
- [ ] In Japanse, it is written in "ですます調 
- [ ] In Japanse, it ends with "。".
- [ ] I've updated [CHANGELOG.md](CHANGELOG.md).
- [ ] I've updated [_index.md](content/_index.md) (when adding MD file).
- [ ] I've updated [sitemap.md](content/about/sitemap.md) (when adding MD file).

### Motivation and Context

This PR relates to <issue>.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
