### PR TITLE
Fix Dir for oss export

### DIFF
--- a/.circleci/oss-deploy.sh
+++ b/.circleci/oss-deploy.sh
@@ -14,11 +14,11 @@ EOL
 
 ## Replace HTML output for OSS deployment
 find ./docs/* -type f -name index.html -exec sed -i -e  's/\/">/\/index.html">/g' {} \;
-find ./docs/* -type f -name index.html -exec sed -i -e 's/help\/image/image/g' {} \;
+### find ./docs/* -type f -name index.html -exec sed -i -e 's/help\/image/image/g' {} \;
 
 ## Deploy to OSS bucket
-ossutil ls oss://technical-reference
-ossutil cp -f  ./docs oss://technical-reference/  --recursive
-ossutil ls oss://technical-reference
+ossutil ls oss://technical-reference/help
+ossutil cp -f  ./docs oss://technical-reference/help  --recursive
+ossutil ls oss://technical-reference/help
 
 # EOF


### PR DESCRIPTION
### Checklist
- [ ] `hugo server` command works fine locally.
- [ ] Table layout looks as it should be.
- [ ] In Japanse, it is written in "ですます調 
- [ ] In Japanse, it ends with "。".
- [ ] I've updated [CHANGELOG.md](CHANGELOG.md).
- [ ] I've added meta-description. (when adding file).
- [ ] I've updated [_index.md](content/_index.md) (when adding/deleting MD file).
- [ ] I've updated [sitemap.md](content/about/sitemap.md) (when adding/deleting MD file).

### Motivation and Context

This PR relates to <issue>.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
